### PR TITLE
Remove bounty banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,6 @@
     </head>
 
     <body>
-        <div class='news'>
-            Compliments of the US Open Data Institute, an address bounty is being offered! Read all about it <a href="https://usodi.org/2014/08/01/openaddresses/">here</a>.
-        </div>
         <div class='bg'>
             <div class='logo'>
                 OpenAddresses


### PR DESCRIPTION
The bounty period ended on October 1, so there's no sense in continuing to advertise it. (I'll tally up all of the pull requests shortly, to figure out how much everybody gets paid.)
