### PR TITLE
Change 'licence' to 'license' on home page to keep the spelling consi…

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ noheader: true
   <div class='col12 clearfix pad4y'>
       <div class='cta col4'>
         <div class='col12 pad4x pad2y prose'>
-          <p><strong>OpenAddresses is open data</strong>. Released under a <a href='http://creativecommons.org/about/cc0'>CC0 License</a>. Individual datasets carry respective licence. </p>
+          <p><strong>OpenAddresses is open data</strong>. Released under a <a href='http://creativecommons.org/about/cc0'>CC0 License</a>. Individual datasets carry respective license. </p>
           <a class='button col12' href='http://data.openaddresses.io/openaddresses-complete.zip'>Download the collection <span class='small quiet'>.csv</span></a>
         </div>
       </div>


### PR DESCRIPTION
…stent on that page

Minor thing, but figured I'd send over a PR. Let me know if people think we should make consistent use of the Commonwealth spelling (licence) instead of the US version I used here!
