### PR TITLE
Re-pointed download link to results page

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ noheader: true
         <div class='col12 pad4x pad2y prose'>
           <p><strong>OpenAddresses is open data</strong>.
             All data is openly licensed. Most sources only require attribution.</p>
-          <a class='button col12' href='http://data.openaddresses.io/openaddresses-collected.zip'>Download the collection <span class='small quiet'>.csv</span></a>
+          <a class='button col12' href='http://results.openaddresses.io'>Download the collection <span class='small quiet'>.csv</span></a>
         </div>
       </div>
 


### PR DESCRIPTION
We are going to have disclaimers there about license status (https://github.com/openaddresses/openaddresses-ops/issues/7), so a simple get-everything zip file link is no longer appropriate on the front page.
