### PR TITLE
Added attribution page with data from OA API

### DIFF
--- a/attribution.html
+++ b/attribution.html
@@ -34,10 +34,10 @@ permalink: /attribution/
 <!--
 
 var req = new XMLHttpRequest();
-req.open("GET", "http://127.0.0.1:5000/latest/licenses.json", false);
+req.open("GET", "http://results.openaddresses.io/latest/licenses.json", false);
 req.send();
 
-var data = JSON.parse(r.responseText),
+var data = JSON.parse(req.responseText),
     list = document.getElementById('attributions'),
     defined = function(a) { return a['attribution'] != undefined },
     compare = function(a, b) { return (a['attribution'] > b['attribution']) ? 1 : -1 },
@@ -45,27 +45,29 @@ var data = JSON.parse(r.responseText),
 
 for(var i = 0; i < licenses.length; i++)
 {
-    var item = document.createElement('li');
+    var item = document.createElement('li'),
+        attr = licenses[i]['attribution'],
+        sources = licenses[i]['sources'];
 
-    item.appendChild(document.createTextNode(licenses[i]['attribution']));
+    item.appendChild(document.createTextNode(attr));
     item.appendChild(document.createTextNode(' – '));
     
-    if(licenses[i]['sources'].length > 2)
+    if(sources.length > 2)
     {
         item.appendChild(document.createElement('br'));
     }
     
-    for(var j = 0; j < licenses[i]['sources'].length; j++)
+    for(var j = 0; j < sources.length; j++)
     {
         var link = document.createElement('a'),
-            name = licenses[i]['sources'][j][0].replace('.json', ''),
-            href = licenses[i]['sources'][j][1];
+            name = sources[j][0].replace('.json', ''),
+            href = sources[j][1];
 
         if(href) { link['href'] = href }
         link.appendChild(document.createTextNode(name));
         item.appendChild(link);
         
-        if(j + 1 < licenses[i]['sources'].length) {
+        if(j + 1 < sources.length) {
             item.appendChild(document.createTextNode(', '));
         } else {
             item.appendChild(document.createTextNode('.'));

--- a/attribution.html
+++ b/attribution.html
@@ -1,0 +1,79 @@
+---
+layout: default
+permalink: /attribution/
+---
+
+<style lang="text/css">
+<!--
+
+    ul#attributions
+    {
+        list-style-type: disc;
+        padding-left: 1.5em;
+    }
+    
+    ul#attributions li a { white-space: nowrap }
+
+-->
+</style>
+
+<section id="js-more" class="limiter clearfix">
+  <div class="col12 clearfix pad4y">
+    <span class="sprite houses block space-bottom2"></span>
+    <div class="col12 clearfix">
+      <div class="col8 margin2">
+        <h2 class="space-bottom1">Required Attribution</h2>
+        <p class="prose">Data can be copied, redistributed, and adapted. For these sources, attribution is required:</p>
+        <ul id="attributions"></ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script language="javascript">
+<!--
+
+var req = new XMLHttpRequest();
+req.open("GET", "http://127.0.0.1:5000/latest/licenses.json", false);
+req.send();
+
+var data = JSON.parse(r.responseText),
+    list = document.getElementById('attributions'),
+    defined = function(a) { return a['attribution'] != undefined },
+    compare = function(a, b) { return (a['attribution'] > b['attribution']) ? 1 : -1 },
+    licenses = data['licenses'].filter(defined).sort(compare);
+
+for(var i = 0; i < licenses.length; i++)
+{
+    var item = document.createElement('li');
+
+    item.appendChild(document.createTextNode(licenses[i]['attribution']));
+    item.appendChild(document.createTextNode(' – '));
+    
+    if(licenses[i]['sources'].length > 2)
+    {
+        item.appendChild(document.createElement('br'));
+    }
+    
+    for(var j = 0; j < licenses[i]['sources'].length; j++)
+    {
+        var link = document.createElement('a'),
+            name = licenses[i]['sources'][j][0].replace('.json', ''),
+            href = licenses[i]['sources'][j][1];
+
+        if(href) { link['href'] = href }
+        link.appendChild(document.createTextNode(name));
+        item.appendChild(link);
+        
+        if(j + 1 < licenses[i]['sources'].length) {
+            item.appendChild(document.createTextNode(', '));
+        } else {
+            item.appendChild(document.createTextNode('.'));
+        }
+    }
+    
+    list.appendChild(item);
+}
+
+-->
+</script>

--- a/attribution.html
+++ b/attribution.html
@@ -34,7 +34,7 @@ permalink: /attribution/
 <!--
 
 var req = new XMLHttpRequest();
-req.open("GET", "http://results.openaddresses.io/latest/licenses.json", false);
+req.open("GET", "https://results.openaddresses.io/latest/licenses.json", false);
 req.send();
 
 var data = JSON.parse(req.responseText),


### PR DESCRIPTION
- [x] Wait for https://github.com/openaddresses/machine/pull/316 to be merged and released.
- [x] Fix localhost URL for license data.

Supports https://github.com/openaddresses/openaddresses-ops/issues/11

Looks like:

<img style="border: 1" width="761" alt="screen shot 2016-03-21 at 10 03 37 pm" src="https://cloud.githubusercontent.com/assets/58730/13942555/d4ae965e-efb0-11e5-8f2e-5d2b60a6a57f.png">
